### PR TITLE
1.11.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ public/*
 .idea/
 
 .DS_Store
+
+examine

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -291,3 +291,8 @@
 1.11.0 2017-04-11
 -----------------
   - updated with happn-2 changes
+
+1.11.1 2017-04-12
+-----------------
+  - fix: event subscriptions don't resume with subscriptionId causing server-side .subscriptionData to be empty 
+  - fix: resumed event subscriptions no longer contain meta

--- a/lib/client.js
+++ b/lib/client.js
@@ -1188,14 +1188,28 @@
 
     var _this = this;
 
-    _this.utils.async(Object.keys(_this.events), function(eventPath, index, next){
+    _this.utils.async(Object.keys(_this.events), function(eventPath, index, next1){
 
       var listeners = _this.events[eventPath];
-      //only refCount - so we not passing any additional parameters like initialValueEmit and initialValueCallback
-      _this._remoteOn(eventPath, {'refCount': listeners.length}, function(e){
-        if (e) return next(new Error('failed re-establishing listener to path: ' + eventPath, e));
-        next();
-      });
+
+      // re-establish each listener individually to preserve original meta and listenerId
+
+      _this.utils.async(listeners, function (listener, index, next2) {
+
+        // we don't pass any additional parameters like initialValueEmit and initialValueCallback
+        var parameters = {
+          refCount: 1,
+          listenerId: listener.id
+        };
+
+        if (listener.meta) parameters.meta = listener.meta;
+
+        _this._remoteOn(eventPath, parameters, function (e) {
+          if (e) return next2(new Error('failed re-establishing listener to path: ' + eventPath, e));
+          next2();
+        });
+
+      }, next1);
 
     }, callback);
   };
@@ -1473,7 +1487,7 @@
 
     if (!_this.events[path]) _this.events[path] = [];
 
-    var listener = {handler: handler, count: parameters.count, id: parameters.listenerId, runcount: 0};
+    var listener = {handler: handler, count: parameters.count, id: parameters.listenerId, runcount: 0, meta: parameters.meta};
 
     _this.events[path].push(listener);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "happn-3",
   "description": "pub/sub api as a service using primus and mongo & redis or nedb, can work as cluster, single process or embedded using nedb",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "./lib/index",
   "protocol": "1.3.0",
   "scripts": {


### PR DESCRIPTION
1.11.1 2017-04-12
-----------------
  - fix: event subscriptions don't resume with subscriptionId causing server-side .subscriptionData to be empty 
  - fix: resumed event subscriptions no longer contain meta