### PR TITLE
10.1.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -608,3 +608,8 @@
   - doc: updated readme
   - dep: updated ws
   - dep: updated happn-stats
+
+10.1.0 2019-07-08
+-----------------
+  - fix #209 - implement ability to respond with a HTML file for unauthorized/forbidden requests
+  - fix #210 - respond with status code '401 Unauthorized' for invalid or missing token instead of '403 Forbidden'

--- a/docs/config.md
+++ b/docs/config.md
@@ -88,7 +88,9 @@ var serverConfig = {
             exclusions: [//http paths to exclude from security checks
               '/test/excluded/specific',
               '/test/excluded/wildcard/*',
-            ]
+            ],
+            unauthorizedResponsePath: path.join(__dirname, 'files/unauthorized.html'), // 401 unauthorized response page (not logged in - token invalid)
+            forbiddenResponsePath: path.join(__dirname, 'files/forbidden.html') // 403 forbidden response page (don't have permissions - token valid)
           }
         }
       }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,5 +1,5 @@
 #happn-3 configuration options:
-*What follows is the full configuartion options for a happn server and client, showing what the defaults are when the config is omitted:*
+*What follows is the full configuration options for a happn server and client, showing what the defaults are when the config is omitted:*
 
 ##server
 ```javascript

--- a/lib/services/connect/middleware/security.js
+++ b/lib/services/connect/middleware/security.js
@@ -1,11 +1,13 @@
 module.exports = SecurityMiddleware;
 
+var fs = require('fs');
 var url = require('url');
 
 SecurityMiddleware.prototype.initialize = initialize;
 SecurityMiddleware.prototype.excluded = excluded;
 SecurityMiddleware.prototype.process = _process;
-SecurityMiddleware.prototype.__respondError = __respondError;
+SecurityMiddleware.prototype.__respondForbidden = __respondForbidden;
+SecurityMiddleware.prototype.__respondUnauthorized = __respondUnauthorized;
 SecurityMiddleware.prototype.__respond = __respond;
 
 function SecurityMiddleware() {}
@@ -94,7 +96,7 @@ function _process(req, res, next) {
 
       var session = _this.happn.services.security.sessionFromRequest(req);
 
-      if (!session) return _this.__respondError(req, res, 'invalid token format or null token');
+      if (!session) return _this.__respondUnauthorized(res, 'invalid token format or null token');
 
       var url = require('url');
 
@@ -106,11 +108,11 @@ function _process(req, res, next) {
 
         if (e) {
 
-          if (e.toString().indexOf('AccessDenied') == 0) return _this.__respondError(req, res, 'unauthorized access to path ' + path);
+          if (e.toString().indexOf('AccessDenied') == 0) return _this.__respondForbidden(res, 'unauthorized access to path ' + path);
           return next(e);
         }
 
-        if (!authorized) return _this.__respondError(req, res, 'unauthorized access to path ' + path);
+        if (!authorized) return _this.__respondForbidden(res, 'unauthorized access to path ' + path);
         req.happn_session = session; //used later if we are rechecking in security
         next();
       });
@@ -122,10 +124,48 @@ function _process(req, res, next) {
     next();
 }
 
-function __respondError(req, res, message) {
-  var url = '/login/?returnUrl=' + req.originalUrl;
-  res.writeHead(301, {Location: url});
-  return res.end(message);
+function __respondForbidden(res, message) {
+  var _this = this;
+
+  if (!_this.config.forbiddenResponsePath) {
+    res.writeHead(403, 'unauthorized access', {
+      'content-type': 'text/plain'
+    });
+    return res.end(message);
+  }
+
+  // todo - what do we want to do with 'message'?
+  fs.readFile(_this.config.forbiddenResponsePath, function (err, html) {
+    if (err) {
+      res.writeHead(500);
+      return res.end(err);
+    }
+
+    res.writeHead(403, 'unauthorized access', {"Content-Type": "text/html"});
+    res.end(html);
+  });
+}
+
+function __respondUnauthorized(res, message) {
+  var _this = this;
+
+  if (!_this.config.unauthorizedResponsePath) {
+    res.writeHead(401, 'unauthorized access', {
+      'content-type': 'text/plain'
+    });
+    return res.end(message);
+  }
+
+  // todo - what do we want to do with 'message'?
+  fs.readFile(_this.config.unauthorizedResponsePath, function (err, html) {
+    if (err) {
+      res.writeHead(500);
+      return res.end(err);
+    }
+
+    res.writeHead(401, 'unauthorized access', {"Content-Type": "text/html"});
+    res.end(html);
+  });
 }
 
 function __respond(message, data, error, res, code) {

--- a/lib/services/connect/middleware/security.js
+++ b/lib/services/connect/middleware/security.js
@@ -134,14 +134,15 @@ function __respondForbidden(res, message) {
     return res.end(message);
   }
 
-  // todo - what do we want to do with 'message'?
   fs.readFile(_this.config.forbiddenResponsePath, function (err, html) {
     if (err) {
       res.writeHead(500);
       return res.end(err);
     }
 
-    res.writeHead(403, 'unauthorized access', {"Content-Type": "text/html"});
+    res.writeHead(403, 'unauthorized access', {
+      "Content-Type": "text/html"
+    });
     res.end(html);
   });
 }
@@ -151,19 +152,22 @@ function __respondUnauthorized(res, message) {
 
   if (!_this.config.unauthorizedResponsePath) {
     res.writeHead(401, 'unauthorized access', {
-      'content-type': 'text/plain'
+      'Content-Type': 'text/plain',
+      'WWW-Authenticate': 'happn-auth'
     });
     return res.end(message);
   }
 
-  // todo - what do we want to do with 'message'?
   fs.readFile(_this.config.unauthorizedResponsePath, function (err, html) {
     if (err) {
       res.writeHead(500);
       return res.end(err);
     }
 
-    res.writeHead(401, 'unauthorized access', {"Content-Type": "text/html"});
+    res.writeHead(401, 'unauthorized access', {
+      "Content-Type": "text/html",
+      'WWW-Authenticate': 'happn-auth'
+    });
     res.end(html);
   });
 }

--- a/lib/services/connect/middleware/security.js
+++ b/lib/services/connect/middleware/security.js
@@ -137,7 +137,7 @@ function __respondForbidden(res, message) {
   fs.readFile(_this.config.forbiddenResponsePath, function (err, html) {
     if (err) {
       res.writeHead(500);
-      return res.end(err);
+      return res.end(_this.happn.services.utils.stringifyError(err));
     }
 
     res.writeHead(403, 'unauthorized access', {
@@ -161,7 +161,7 @@ function __respondUnauthorized(res, message) {
   fs.readFile(_this.config.unauthorizedResponsePath, function (err, html) {
     if (err) {
       res.writeHead(500);
-      return res.end(err);
+      return res.end(_this.happn.services.utils.stringifyError(err));
     }
 
     res.writeHead(401, 'unauthorized access', {

--- a/lib/services/connect/middleware/security.js
+++ b/lib/services/connect/middleware/security.js
@@ -94,7 +94,7 @@ function _process(req, res, next) {
 
       var session = _this.happn.services.security.sessionFromRequest(req);
 
-      if (!session) return _this.__respondError(res, 'invalid token format or null token');
+      if (!session) return _this.__respondError(req, res, 'invalid token format or null token');
 
       var url = require('url');
 
@@ -106,11 +106,11 @@ function _process(req, res, next) {
 
         if (e) {
 
-          if (e.toString().indexOf('AccessDenied') == 0) return _this.__respondError(res, 'unauthorized access to path ' + path);
+          if (e.toString().indexOf('AccessDenied') == 0) return _this.__respondError(req, res, 'unauthorized access to path ' + path);
           return next(e);
         }
 
-        if (!authorized) return _this.__respondError(res, 'unauthorized access to path ' + path);
+        if (!authorized) return _this.__respondError(req, res, 'unauthorized access to path ' + path);
         req.happn_session = session; //used later if we are rechecking in security
         next();
       });
@@ -122,10 +122,9 @@ function _process(req, res, next) {
     next();
 }
 
-function __respondError(res, message) {
-  res.writeHead(403, 'unauthorized access', {
-    'content-type': 'text/plain'
-  });
+function __respondError(req, res, message) {
+  var url = '/login/?returnUrl=' + req.originalUrl;
+  res.writeHead(301, {Location: url});
   return res.end(message);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "happn-3",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "happn-3",
   "description": "pub/sub api as a service using primus and mongo & redis or nedb, can work as cluster, single process or embedded using nedb",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "main": "./lib/index",
   "protocol": "4",
   "database": "1",

--- a/test/integration/security/files/forbidden.html
+++ b/test/integration/security/files/forbidden.html
@@ -1,0 +1,3 @@
+<body>
+Forbidden
+</body>

--- a/test/integration/security/files/unauthorized.html
+++ b/test/integration/security/files/unauthorized.html
@@ -1,0 +1,3 @@
+<body>
+Unauthorized
+</body>

--- a/test/integration/security/unauthorized-requests.js
+++ b/test/integration/security/unauthorized-requests.js
@@ -1,0 +1,284 @@
+describe.only(require('../../__fixtures/utils/test_helper').create().testName(__filename, 3), function () {
+
+  var path = require('path');
+  var expect = require('expect.js');
+  var happn = require('../../../lib/index');
+  var service = happn.service;
+
+  function doRequest(path, token, query, callback, excludeToken) {
+
+    var request = require('request');
+
+    var options = {
+      url: 'http://127.0.0.1:55000' + path
+    };
+
+    if (!excludeToken) {
+      if (!query)
+        options.headers = {
+          'Cookie': ['happn_token=' + token]
+        };
+      else
+        options.url += '?happn_token=' + token;
+    }
+
+    request(options, function (error, response, body) {
+      callback(response, body);
+    });
+
+  }
+
+  context('secure mesh', function () {
+    var self = this;
+    setup.apply(self, [{
+      secure: true
+    }]);
+
+    it('the server should respond with \'200 OK\' when request has valid token', function (callback) {
+
+      try {
+
+        doRequest('/secure/route/test', self.adminClient.session.token, false, function (response) {
+
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers['content-type']).to.equal('application/json');
+          expect(response.body).to.equal('{"secure":"value"}');
+          callback();
+
+        });
+
+      } catch (e) {
+        callback(e);
+      }
+
+    });
+
+    it('the server should respond with \'401 Unauthorized\' when request has no token', function (callback) {
+
+      try {
+
+        doRequest('/secure/route/test', null, false, function (response) {
+
+          expect(response.statusCode).to.equal(401);
+          expect(response.headers['content-type']).to.equal('text/plain');
+          expect(response.headers['www-authenticate']).to.equal('happn-auth');
+          expect(response.body).to.equal('invalid token format or null token');
+
+          callback();
+
+        });
+
+      } catch (e) {
+        callback(e);
+      }
+
+    });
+
+    it('the server should respond with \'403 Forbidden\' when request has token from client without permission', function (callback) {
+
+      try {
+
+        doRequest('/secure/route/test', self.testClient.session.token, false, function (response) {
+
+          expect(response.statusCode).to.equal(403);
+          expect(response.headers['content-type']).to.equal('text/plain');
+          expect(response.body).to.equal('unauthorized access to path /@HTTP/secure/route/test');
+          callback();
+
+        });
+
+      } catch (e) {
+        callback(e);
+      }
+
+    });
+  });
+
+  context('secure mesh with configured \'unauthorizedResponsePath\' and \'forbiddenResponsePath\'', function () {
+    var self = this;
+    setup.apply(self, [{
+      secure: true,
+      services: {
+        connect: {
+          config: {
+            middleware: {
+              security: {
+                unauthorizedResponsePath: path.join(__dirname, 'files/unauthorized.html'),
+                forbiddenResponsePath: path.join(__dirname, 'files/forbidden.html')
+              }
+            }
+          }
+        }
+      }
+    }]);
+
+    it('the server should respond with \'401 Unauthorized\' with custom unauthorized HTML page when request has no token', function (callback) {
+
+      try {
+
+        doRequest('/secure/route/test', null, false, function (response) {
+
+          expect(response.statusCode).to.equal(401);
+          expect(response.headers['content-type']).to.equal('text/html');
+          expect(response.headers['www-authenticate']).to.equal('happn-auth');
+          expect(response.body).to.equal("<body>\nUnauthorized\n</body>\n");
+          callback();
+
+        });
+
+      } catch (e) {
+        callback(e);
+      }
+
+    });
+
+    it('the server should respond with \'403 Forbidden\' with custom forbidden HTML page when request has token from client without permission', function (callback) {
+
+      try {
+
+        doRequest('/secure/route/test', self.testClient.session.token, false, function (response) {
+
+          expect(response.statusCode).to.equal(403);
+          expect(response.headers['content-type']).to.equal('text/html');
+          expect(response.body).to.equal("<body>\nForbidden\n</body>\n");
+          callback();
+
+        });
+
+      } catch (e) {
+        callback(e);
+      }
+
+    });
+  });
+
+  function setup(config) {
+    var self = this;
+
+    var happnInstance = null;
+    var test_id = Date.now() + '_' + require('shortid').generate();
+
+
+    before('should initialize the service', function (callback) {
+
+      this.timeout(20000);
+      try {
+        service.create(config, function (e, happnInst) {
+          if (e)
+            return callback(e);
+
+          happnInstance = happnInst;
+
+          happnInstance.connect.use('/secure/route/test', function (req, res, next) {
+
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({
+              "secure": "value"
+            }));
+
+          });
+
+          callback();
+
+        });
+      } catch (e) {
+        callback(e);
+      }
+    });
+
+    after(function (done) {
+
+      this.timeout(15000);
+
+      if (self.adminClient) self.adminClient.disconnect({reconnect: false});
+      if (self.testClient) self.testClient.disconnect({reconnect: false});
+
+      setTimeout(function(){
+        happnInstance.stop({reconnect: false}, done);
+      }, 10000);
+    });
+
+    before('should initialize the admin client', function (callback) {
+
+      happn.client.create({
+        config: {
+          username: '_ADMIN',
+          password: 'happn'
+        },
+        secure: true
+      })
+
+        .then(function (clientInstance) {
+          self.adminClient = clientInstance;
+          callback();
+        })
+
+        .catch(function (e) {
+          callback(e);
+        });
+
+    });
+
+    var testGroup = {
+      name: 'TEST GROUP' + test_id,
+      custom_data: {
+        customString: 'custom1',
+        customNumber: 0
+      }
+    };
+
+    var testUser = {
+      username: 'TEST USER@blah.com' + test_id,
+      password: 'TEST PWD',
+      custom_data: {
+        something: 'usefull'
+      }
+    };
+
+    var addedTestGroup;
+    var addedTestuser;
+
+    before('creates a group and a user, adds the group to the user, logs in with test user', function (done) {
+
+      happnInstance.services.security.users.upsertGroup(testGroup, {
+        overwrite: false
+      }, function (e, result) {
+
+        if (e) return done(e);
+        addedTestGroup = result;
+
+        happnInstance.services.security.users.upsertUser(testUser, {
+          overwrite: false
+        }, function (e, result) {
+
+          if (e) return done(e);
+          addedTestuser = result;
+
+          happnInstance.services.security.users.linkGroup(addedTestGroup, addedTestuser, function (e) {
+
+            if (e) return done(e);
+
+            happn.client.create({
+              config: {
+                username: testUser.username,
+                password: 'TEST PWD'
+              },
+              secure: true
+            })
+
+              .then(function (clientInstance) {
+                self.testClient = clientInstance;
+                done();
+              })
+
+              .catch(function (e) {
+                done(e);
+              });
+
+          });
+        });
+      });
+    });
+  }
+
+});

--- a/test/integration/security/unauthorized-requests.js
+++ b/test/integration/security/unauthorized-requests.js
@@ -1,31 +1,22 @@
 describe(require('../../__fixtures/utils/test_helper').create().testName(__filename, 3), function () {
 
   var path = require('path');
+  var request = require('request');
   var expect = require('expect.js');
   var happn = require('../../../lib/index');
   var service = happn.service;
 
-  function doRequest(path, token, query, callback, excludeToken) {
-
-    var request = require('request');
-
+  function doRequest(path, token, callback) {
     var options = {
-      url: 'http://127.0.0.1:55000' + path
+      url: 'http://127.0.0.1:55000' + path,
+      headers: {
+        'Cookie': ['happn_token=' + token]
+      }
     };
-
-    if (!excludeToken) {
-      if (!query)
-        options.headers = {
-          'Cookie': ['happn_token=' + token]
-        };
-      else
-        options.url += '?happn_token=' + token;
-    }
 
     request(options, function (error, response, body) {
       callback(response, body);
     });
-
   }
 
   context('secure mesh', function () {
@@ -38,7 +29,7 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       try {
 
-        doRequest('/secure/route/test', self.adminClient.session.token, false, function (response) {
+        doRequest('/secure/route/test', self.adminClient.session.token, function (response) {
 
           expect(response.statusCode).to.equal(200);
           expect(response.headers['content-type']).to.equal('application/json');
@@ -57,7 +48,7 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       try {
 
-        doRequest('/secure/route/test', null, false, function (response) {
+        doRequest('/secure/route/test', null, function (response) {
 
           expect(response.statusCode).to.equal(401);
           expect(response.headers['content-type']).to.equal('text/plain');
@@ -78,7 +69,7 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       try {
 
-        doRequest('/secure/route/test', self.testClient.session.token, false, function (response) {
+        doRequest('/secure/route/test', self.testClient.session.token, function (response) {
 
           expect(response.statusCode).to.equal(403);
           expect(response.headers['content-type']).to.equal('text/plain');
@@ -116,7 +107,7 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       try {
 
-        doRequest('/secure/route/test', null, false, function (response) {
+        doRequest('/secure/route/test', null, function (response) {
 
           expect(response.statusCode).to.equal(401);
           expect(response.headers['content-type']).to.equal('text/html');
@@ -136,7 +127,7 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       try {
 
-        doRequest('/secure/route/test', self.testClient.session.token, false, function (response) {
+        doRequest('/secure/route/test', self.testClient.session.token, function (response) {
 
           expect(response.statusCode).to.equal(403);
           expect(response.headers['content-type']).to.equal('text/html');
@@ -174,7 +165,7 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       try {
 
-        doRequest('/secure/route/test', null, false, function (response) {
+        doRequest('/secure/route/test', null, function (response) {
 
           expect(response.statusCode).to.equal(500);
           expect(response.body.indexOf('ENOENT')).to.not.eql(-1);
@@ -192,7 +183,7 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       try {
 
-        doRequest('/secure/route/test', self.testClient.session.token, false, function (response) {
+        doRequest('/secure/route/test', self.testClient.session.token, function (response) {
 
           expect(response.statusCode).to.equal(500);
           expect(response.body.indexOf('ENOENT')).to.not.eql(-1);

--- a/test/integration/security/unauthorized-requests.js
+++ b/test/integration/security/unauthorized-requests.js
@@ -1,4 +1,4 @@
-describe.only(require('../../__fixtures/utils/test_helper').create().testName(__filename, 3), function () {
+describe(require('../../__fixtures/utils/test_helper').create().testName(__filename, 3), function () {
 
   var path = require('path');
   var expect = require('expect.js');
@@ -141,6 +141,61 @@ describe.only(require('../../__fixtures/utils/test_helper').create().testName(__
           expect(response.statusCode).to.equal(403);
           expect(response.headers['content-type']).to.equal('text/html');
           expect(response.body).to.equal("<body>\nForbidden\n</body>\n");
+          callback();
+
+        });
+
+      } catch (e) {
+        callback(e);
+      }
+
+    });
+  });
+
+  context('secure mesh with invalid \'unauthorizedResponsePath\' and \'forbiddenResponsePath\'', function () {
+    var self = this;
+    setup.apply(self, [{
+      secure: true,
+      services: {
+        connect: {
+          config: {
+            middleware: {
+              security: {
+                unauthorizedResponsePath: path.join(__dirname, 'invalid/invalid.html'),
+                forbiddenResponsePath: path.join(__dirname, 'invalid/invalid.html')
+              }
+            }
+          }
+        }
+      }
+    }]);
+
+    it('the server should respond with \'500 Internal Server Error\' for invalid \'unauthorizedResponsePath\'', function (callback) {
+
+      try {
+
+        doRequest('/secure/route/test', null, false, function (response) {
+
+          expect(response.statusCode).to.equal(500);
+          expect(response.body.indexOf('ENOENT')).to.not.eql(-1);
+          callback();
+
+        });
+
+      } catch (e) {
+        callback(e);
+      }
+
+    });
+
+    it('the server should respond with \'500 Internal Server Error\' for invalid \'forbiddenResponsePath\'', function (callback) {
+
+      try {
+
+        doRequest('/secure/route/test', self.testClient.session.token, false, function (response) {
+
+          expect(response.statusCode).to.equal(500);
+          expect(response.body.indexOf('ENOENT')).to.not.eql(-1);
           callback();
 
         });

--- a/test/integration/security/web_token_sanity.js
+++ b/test/integration/security/web_token_sanity.js
@@ -718,40 +718,4 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
     }
   });
 
-  it('the server should respond with \'401 Unauthorized\' when request has no token', function (callback) {
-
-    try {
-
-      doRequest('/secure/route/test', null, false, function (response) {
-
-        expect(response.statusCode).to.equal(401);
-        expect(response.headers['content-type']).to.equal('text/plain');
-        expect(response.headers['www-authenticate']).to.equal('happn-auth');
-        callback();
-
-      });
-
-    } catch (e) {
-      callback(e);
-    }
-
-  });
-
-  it('the server should respond with \'403 Forbidden\' when request has token from client without permission', function (callback) {
-
-    try {
-
-      doRequest('/secure/route/test', testClient.session.token, false, function (response) {
-
-        expect(response.statusCode).to.equal(403);
-        expect(response.headers['content-type']).to.equal('text/plain');
-        callback();
-
-      });
-
-    } catch (e) {
-      callback(e);
-    }
-
-  });
 });

--- a/test/integration/security/web_token_sanity.js
+++ b/test/integration/security/web_token_sanity.js
@@ -709,12 +709,49 @@ describe(require('../../__fixtures/utils/test_helper').create().testName(__filen
 
       doBearerTokenRequest('/secure/route/test', 'crap token', function (response) {
 
-        expect(response.statusCode).to.equal(403);
+        expect(response.statusCode).to.equal(401);
         callback();
       });
 
     } catch (e) {
       callback(e);
     }
+  });
+
+  it('the server should respond with \'401 Unauthorized\' when request has no token', function (callback) {
+
+    try {
+
+      doRequest('/secure/route/test', null, false, function (response) {
+
+        expect(response.statusCode).to.equal(401);
+        expect(response.headers['content-type']).to.equal('text/plain');
+        expect(response.headers['www-authenticate']).to.equal('happn-auth');
+        callback();
+
+      });
+
+    } catch (e) {
+      callback(e);
+    }
+
+  });
+
+  it('the server should respond with \'403 Forbidden\' when request has token from client without permission', function (callback) {
+
+    try {
+
+      doRequest('/secure/route/test', testClient.session.token, false, function (response) {
+
+        expect(response.statusCode).to.equal(403);
+        expect(response.headers['content-type']).to.equal('text/plain');
+        callback();
+
+      });
+
+    } catch (e) {
+      callback(e);
+    }
+
   });
 });


### PR DESCRIPTION
- fix #209 - implement ability to respond with a HTML file for unauthorized/forbidden requests
- fix #210 - respond with status code '401 Unauthorized' for invalid or missing token instead of '403 Forbidden'
